### PR TITLE
Python 3 compatibility and t-batch caching.

### DIFF
--- a/evaluate_interaction_prediction.py
+++ b/evaluate_interaction_prediction.py
@@ -27,7 +27,7 @@ args.datapath = "data/%s.csv" % args.network
 if args.train_proportion > 0.8:
     sys.exit('Training sequence proportion cannot be greater than 0.8.')
 if args.network == "mooc":
-    print "No interaction prediction for %s" % args.network
+    print("No interaction prediction for %s" % args.network)
     sys.exit(0)
     
 # SET GPU
@@ -43,7 +43,7 @@ if os.path.exists(output_fname):
     for l in f:
         l = l.strip()
         if search_string in l:
-            print "Output file already has results of epoch %d" % args.epoch
+            print("Output file already has results of epoch %d" % args.epoch)
             sys.exit(0)
     f.close()
 
@@ -58,7 +58,7 @@ num_features = len(feature_sequence[0])
 num_users = len(user2id)
 num_items = len(item2id) + 1
 true_labels_ratio = len(y_true)/(sum(y_true)+1)
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
 
 # SET TRAIN, VALIDATION, AND TEST BOUNDARIES
 train_end_idx = validation_start_idx = int(num_interactions * args.train_proportion)
@@ -121,7 +121,7 @@ Please note that since each interaction in validation and test is only seen once
 tbatch_start_time = None
 loss = 0
 # FORWARD PASS
-print "*** Making interaction predictions by forward pass (no t-batching) ***"
+print("*** Making interaction predictions by forward pass (no t-batching) ***")
 with trange(train_end_idx, test_end_idx) as progress_bar:
     for j in progress_bar:
         progress_bar.set_description('%dth interaction for validation and testing' % j)
@@ -218,13 +218,13 @@ performance_dict['test'] = [mrr, rec10]
 fw = open(output_fname, "a")
 metrics = ['Mean Reciprocal Rank', 'Recall@10']
 
-print '\n\n*** Validation performance of epoch %d ***' % args.epoch
+print('\n\n*** Validation performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Validation performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['validation'][i]))
     fw.write("Validation: " + metrics[i] + ': ' + str(performance_dict['validation'][i]) + "\n")
     
-print '\n\n*** Test performance of epoch %d ***' % args.epoch
+print('\n\n*** Test performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Test performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['test'][i]))

--- a/evaluate_state_change_prediction.py
+++ b/evaluate_state_change_prediction.py
@@ -28,7 +28,7 @@ args.datapath = "data/%s.csv" % args.network
 if args.train_proportion > 0.8:
     sys.exit('Training sequence proportion cannot be greater than 0.8.')
 if args.network == "lastfm":
-    print "No state change prediction for %s" % args.network
+    print("No state change prediction for %s" % args.network)
     sys.exit(0)
     
 # SET GPU
@@ -44,7 +44,7 @@ if os.path.exists(output_fname):
     for l in f:
         l = l.strip()
         if search_string in l:
-            print "Output file already has results of epoch %d" % args.epoch
+            print("Output file already has results of epoch %d" % args.epoch)
             sys.exit(0)
     f.close()
 
@@ -59,7 +59,7 @@ num_features = len(feature_sequence[0])
 num_users = len(user2id)
 num_items = len(item2id) + 1
 true_labels_ratio = len(y_true)/(sum(y_true)+1)
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
         
 # SET TRAIN, VALIDATION, AND TEST BOUNDARIES
 train_end_idx = validation_start_idx = int(num_interactions * args.train_proportion)
@@ -124,7 +124,7 @@ Please note that since each interaction in validation and test is only seen once
 tbatch_start_time = None
 loss = 0
 # FORWARD PASS
-print "*** Making state change predictions by forward pass (no t-batching) ***"
+print("*** Making state change predictions by forward pass (no t-batching) ***")
 with trange(train_end_idx, test_end_idx) as progress_bar:
     for j in progress_bar:
         progress_bar.set_description('%dth interaction for validation and testing' % j)
@@ -218,14 +218,14 @@ performance_dict['test'] = [auc]
 fw = open(output_fname, "a")
 metrics = ['AUC']
 
-print '\n\n*** Validation performance of epoch %d ***' % args.epoch
+print('\n\n*** Validation performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Validation performance of epoch %d ***\n' % args.epoch)
 
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['validation'][i]))
     fw.write("Validation: " + metrics[i] + ': ' + str(performance_dict['validation'][i]) + "\n")
 
-print '\n\n*** Test performance of epoch %d ***' % args.epoch
+print('\n\n*** Test performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Test performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['test'][i]))

--- a/get_final_performance_numbers.py
+++ b/get_final_performance_numbers.py
@@ -43,13 +43,13 @@ if "interaction" in fname:
 else:
     metrics = ['AUC']
 
-print '\n\n*** For file: %s ***' % fname
+print('\n\n*** For file: %s ***' % fname)
 best_val_idx = np.argmax(validation_performances[:,1])
-print "Best validation epoch: %d" % best_val_idx
-print '\n\n*** Best validation performance (epoch %d) ***' % best_val_idx
+print("Best validation epoch: %d" % best_val_idx)
+print('\n\n*** Best validation performance (epoch %d) ***' % best_val_idx)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(validation_performances[best_val_idx][i+1]))
 
-print '\n\n*** Final model performance on the test set, i.e., in epoch %d ***' % best_val_idx
+print('\n\n*** Final model performance on the test set, i.e., in epoch %d ***' % best_val_idx)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(test_performances[best_val_idx][i+1]))

--- a/jodie.py
+++ b/jodie.py
@@ -42,7 +42,7 @@ num_users = len(user2id)
 num_items = len(item2id) + 1 # one extra item for "none-of-these"
 num_features = len(feature_sequence[0])
 true_labels_ratio = len(y_true)/(1.0+sum(y_true)) # +1 in denominator in case there are no state change labels, which will throw an error. 
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
 
 # SET TRAINING, VALIDATION, TESTING, and TBATCH BOUNDARIES
 train_end_idx = validation_start_idx = int(num_interactions * args.train_proportion) 
@@ -85,7 +85,7 @@ optimizer = optim.Adam(model.parameters(), lr=learning_rate, weight_decay=1e-5)
 '''
 THE MODEL IS TRAINED FOR SEVERAL EPOCHS. IN EACH EPOCH, JODIES USES THE TRAINING SET OF INTERACTIONS TO UPDATE ITS PARAMETERS.
 '''
-print "*** Training the JODIE model for %d epochs ***" % args.epochs
+print("*** Training the JODIE model for %d epochs ***" % args.epochs)
 with trange(args.epochs) as progress_bar1:
     for ep in progress_bar1:
         progress_bar1.set_description('Epoch %d of %d' % (ep, args.epochs))
@@ -200,7 +200,7 @@ with trange(args.epochs) as progress_bar1:
                     tbatch_to_insert = -1
 
         # END OF ONE EPOCH 
-        print "\n\nTotal loss in this epoch = %f" % (total_loss)
+        print("\n\nTotal loss in this epoch = %f" % (total_loss))
         item_embeddings_dystat = torch.cat([item_embeddings, item_embedding_static], dim=1)
         user_embeddings_dystat = torch.cat([user_embeddings, user_embedding_static], dim=1)
         # SAVE CURRENT MODEL TO DISK TO BE USED IN EVALUATION.
@@ -210,6 +210,6 @@ with trange(args.epochs) as progress_bar1:
         item_embeddings = initial_item_embedding.repeat(num_items, 1)
 
 # END OF ALL EPOCHS. SAVE FINAL MODEL DISK TO BE USED IN EVALUATION.
-print "\n\n*** Training complete. Saving final model. ***\n\n"
+print("\n\n*** Training complete. Saving final model. ***\n\n")
 save_model(model, optimizer, args, ep, user_embeddings_dystat, item_embeddings_dystat, train_end_idx, user_embeddings_timeseries, item_embeddings_timeseries)
 

--- a/library_data.py
+++ b/library_data.py
@@ -40,7 +40,7 @@ def load_network(args, time_scaling=True):
     start_timestamp = None
     y_true_labels = []
 
-    print "\n\n**** Loading %s network from file: %s ****" % (network, datapath)
+    print("\n\n**** Loading %s network from file: %s ****" % (network, datapath))
     f = open(datapath,"r")
     f.readline()
     for cnt, l in enumerate(f):
@@ -59,7 +59,7 @@ def load_network(args, time_scaling=True):
     item_sequence = np.array(item_sequence)
     timestamp_sequence = np.array(timestamp_sequence)
 
-    print "Formating item sequence"
+    print("Formating item sequence")
     nodeid = 0
     item2id = {}
     item_timedifference_sequence = []
@@ -74,7 +74,7 @@ def load_network(args, time_scaling=True):
     num_items = len(item2id)
     item_sequence_id = [item2id[item] for item in item_sequence]
 
-    print "Formating user sequence"
+    print("Formating user sequence")
     nodeid = 0
     user2id = {}
     user_timedifference_sequence = []
@@ -94,11 +94,11 @@ def load_network(args, time_scaling=True):
     user_sequence_id = [user2id[user] for user in user_sequence]
 
     if time_scaling:
-        print "Scaling timestamps"
+        print("Scaling timestamps")
         user_timedifference_sequence = scale(np.array(user_timedifference_sequence) + 1)
         item_timedifference_sequence = scale(np.array(item_timedifference_sequence) + 1)
 
-    print "*** Network loading completed ***\n\n"
+    print("*** Network loading completed ***\n\n")
     return [user2id, user_sequence_id, user_timedifference_sequence, user_previous_itemid_sequence, \
         item2id, item_sequence_id, item_timedifference_sequence, \
         timestamp_sequence, \

--- a/library_data.py
+++ b/library_data.py
@@ -51,7 +51,7 @@ def load_network(args, time_scaling=True):
             start_timestamp = float(ls[2])
         timestamp_sequence.append(float(ls[2]) - start_timestamp) 
         y_true_labels.append(int(ls[3])) # label = 1 at state change, 0 otherwise
-        feature_sequence.append(map(float,ls[4:]))
+        feature_sequence.append(list(map(float,ls[4:])))
     f.close()
 
     user_sequence = np.array(user_sequence) 

--- a/library_data.py
+++ b/library_data.py
@@ -12,7 +12,6 @@ import operator
 import copy
 from collections import defaultdict
 import os, re
-import cPickle
 import argparse
 from sklearn.preprocessing import scale
 

--- a/library_models.py
+++ b/library_models.py
@@ -46,7 +46,7 @@ class JODIE(nn.Module):
     def __init__(self, args, num_features, num_users, num_items):
         super(JODIE,self).__init__()
 
-        print "*** Initializing the JODIE model ***"
+        print("*** Initializing the JODIE model ***")
         self.modelname = args.model
         self.embedding_dim = args.embedding_dim
         self.num_users = num_users
@@ -54,22 +54,22 @@ class JODIE(nn.Module):
         self.user_static_embedding_size = num_users
         self.item_static_embedding_size = num_items
 
-        print "Initializing user and item embeddings"
+        print("Initializing user and item embeddings")
         self.initial_user_embedding = nn.Parameter(torch.Tensor(args.embedding_dim))
         self.initial_item_embedding = nn.Parameter(torch.Tensor(args.embedding_dim))
 
         rnn_input_size_items = rnn_input_size_users = self.embedding_dim + 1 + num_features
 
-        print "Initializing user and item RNNs"
+        print("Initializing user and item RNNs")
         self.item_rnn = nn.RNNCell(rnn_input_size_users, self.embedding_dim)
         self.user_rnn = nn.RNNCell(rnn_input_size_items, self.embedding_dim)
 
-        print "Initializing linear layers"
+        print("Initializing linear layers")
         self.linear_layer1 = nn.Linear(self.embedding_dim, 50)
         self.linear_layer2 = nn.Linear(50, 2)
         self.prediction_layer = nn.Linear(self.user_static_embedding_size + self.item_static_embedding_size + self.embedding_dim * 2, self.item_static_embedding_size + self.embedding_dim)
         self.embedding_layer = NormalLinear(1, self.embedding_dim)
-        print "*** JODIE initialization complete ***\n\n"
+        print("*** JODIE initialization complete ***\n\n")
         
     def forward(self, user_embeddings, item_embeddings, timediffs=None, features=None, select=None):
         if select == 'item_update':
@@ -141,7 +141,7 @@ def calculate_state_prediction_loss(model, tbatch_interactionids, user_embedding
 
 # SAVE TRAINED MODEL TO DISK
 def save_model(model, optimizer, args, epoch, user_embeddings, item_embeddings, train_end_idx, user_embeddings_time_series=None, item_embeddings_time_series=None, path=PATH):
-    print "*** Saving embeddings and model ***"
+    print("*** Saving embeddings and model ***")
     state = {
             'user_embeddings': user_embeddings.data.cpu().numpy(),
             'item_embeddings': item_embeddings.data.cpu().numpy(),
@@ -161,7 +161,7 @@ def save_model(model, optimizer, args, epoch, user_embeddings, item_embeddings, 
 
     filename = os.path.join(directory, "checkpoint.%s.ep%d.tp%.1f.pth.tar" % (args.model, epoch, args.train_proportion))
     torch.save(state, filename)
-    print "*** Saved embeddings and model to file: %s ***\n\n" % filename
+    print("*** Saved embeddings and model to file: %s ***\n\n" % filename)
 
 
 # LOAD PREVIOUSLY TRAINED AND SAVED MODEL
@@ -169,7 +169,7 @@ def load_model(model, optimizer, args, epoch):
     modelname = args.model
     filename = PATH + "saved_models/%s/checkpoint.%s.ep%d.tp%.1f.pth.tar" % (args.network, modelname, epoch, args.train_proportion)
     checkpoint = torch.load(filename)
-    print "Loading saved embeddings and model: %s" % filename
+    print("Loading saved embeddings and model: %s" % filename)
     args.start_epoch = checkpoint['epoch']
     user_embeddings = Variable(torch.from_numpy(checkpoint['user_embeddings']).cuda())
     item_embeddings = Variable(torch.from_numpy(checkpoint['item_embeddings']).cuda())

--- a/library_models.py
+++ b/library_models.py
@@ -15,7 +15,6 @@ import math, random
 import sys
 from collections import defaultdict
 import os
-import cPickle
 import gpustat
 from itertools import chain
 from tqdm import tqdm, trange, tqdm_notebook, tnrange

--- a/library_models.py
+++ b/library_models.py
@@ -19,6 +19,7 @@ import gpustat
 from itertools import chain
 from tqdm import tqdm, trange, tqdm_notebook, tnrange
 import csv
+import json
 
 PATH = "./"
 
@@ -125,6 +126,39 @@ def reinitialize_tbatches():
 
     global total_reinitialization_count
     total_reinitialization_count +=1
+
+# LOAD/SAVE TBATCHES
+def save_tbatch_object(filename, tbatch):
+    with open(filename, 'w') as f:
+        f.write(json.dumps(tbatch))
+
+def load_tbatch_object(filename, tbatch):
+    with open(filename) as f:
+        return json.loads(f.read())
+
+def save_tbatches(dir):
+    save_tbatch_object(os.path.join(dir, "interactionids"), current_tbatches_interactionids)
+    save_tbatch_object(os.path.join(dir, "user"), current_tbatches_user)
+    save_tbatch_object(os.path.join(dir, "item"), current_tbatches_item)
+    save_tbatch_object(os.path.join(dir, "timestamp"), current_tbatches_timestamp)
+    save_tbatch_object(os.path.join(dir, "feature"), current_tbatches_feature)
+    save_tbatch_object(os.path.join(dir, "label"), current_tbatches_label)
+    save_tbatch_object(os.path.join(dir, "previous_item"), current_tbatches_previous_item)
+    save_tbatch_object(os.path.join(dir, "user_timediffs"), current_tbatches_user_timediffs)
+    save_tbatch_object(os.path.join(dir, "item_timediffs"), current_tbatches_item_timediffs)
+    save_tbatch_object(os.path.join(dir, "user_timediffs_next"), current_tbatches_user_timediffs_next)
+
+def load_tbatches(dir):
+    load_tbatch_object(os.path.join(dir, "interactionids"), current_tbatches_interactionids)
+    load_tbatch_object(os.path.join(dir, "user"), current_tbatches_user)
+    load_tbatch_object(os.path.join(dir, "item"), current_tbatches_item)
+    load_tbatch_object(os.path.join(dir, "timestamp"), current_tbatches_timestamp)
+    load_tbatch_object(os.path.join(dir, "feature"), current_tbatches_feature)
+    load_tbatch_object(os.path.join(dir, "label"), current_tbatches_label)
+    load_tbatch_object(os.path.join(dir, "previous_item"), current_tbatches_previous_item)
+    load_tbatch_object(os.path.join(dir, "user_timediffs"), current_tbatches_user_timediffs)
+    load_tbatch_object(os.path.join(dir, "item_timediffs"), current_tbatches_item_timediffs)
+    load_tbatch_object(os.path.join(dir, "user_timediffs_next"), current_tbatches_user_timediffs_next)
 
 
 # CALCULATE LOSS FOR THE PREDICTED USER STATE 

--- a/tbatch.py
+++ b/tbatch.py
@@ -28,7 +28,7 @@ num_users = len(user2id)
 num_items = len(item2id) + 1 # one extra item for "none-of-these"
 num_features = len(feature_sequence[0])
 true_labels_ratio = len(y_true)/(1.0+sum(y_true)) # +1 in denominator in case there are no state change labels, which will throw an error. 
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
 
 # OUTPUT FILE FOR THE BATCHES
 output_fname = "results/batches_%s.txt" % args.network
@@ -52,7 +52,7 @@ timespan = timestamp_sequence[-1] - timestamp_sequence[0]
 tbatch_timespan = timespan / 500 
 
 # CREATE THE TBATCHES
-print "*** Creating T-batches from %d interactions ***" % train_end_idx
+print("*** Creating T-batches from %d interactions ***" % train_end_idx)
 # INITIALIZE TBATCH PARAMETERS
 tbatch_start_time = None
 tbatch_to_insert = -1
@@ -98,7 +98,7 @@ for j in range(num_interactions):
     # AFTER PROCESSING ALL INTERACTIONS IN A TIMESPAN
     if timestamp - tbatch_start_time > tbatch_timespan or j == num_interactions - 1:
         # AFTER ALL INTERACTIONS IN THE TIME WINDOW ARE CONVERTED TO T-BATCHES, SAVE THEM TO FILE.
-        print 'Read till interaction %d. This timespan had %d interactions and created %d T-batches.' % (j, tbatch_interaction_count, len(lib.current_tbatches_user))
+        print('Read till interaction %d. This timespan had %d interactions and created %d T-batches.' % (j, tbatch_interaction_count, len(lib.current_tbatches_user)))
         total_tbatches_count += len(lib.current_tbatches_user)
         total_interactions_count += tbatch_interaction_count 
 
@@ -127,8 +127,8 @@ for j in range(num_interactions):
         tbatch_to_insert = -1
 
 fout.close()
-print "======================="
-print "T-batching complete. Output file: %s." % output_fname
-print "%d interactions were processed, which created %d t-batches." % (total_interactions_count, total_tbatches_count)
-print "This is a %.3f%% compression." % ((total_interactions_count - total_tbatches_count)*100.0/total_interactions_count)
-print "======================="
+print("=======================")
+print("T-batching complete. Output file: %s." % output_fname)
+print("%d interactions were processed, which created %d t-batches." % (total_interactions_count, total_tbatches_count))
+print("This is a %.3f%% compression." % ((total_interactions_count - total_tbatches_count)*100.0/total_interactions_count))
+print("=======================")


### PR DESCRIPTION
The first 3 commits address python 3 compatibility and remove unnecessary imports.

The final commit is an incomplete tbatching optimization. We don't need to recompute tbatches for every epoch, so it makes sense to do some type of caching. Also, we don't need to recompute them for every run either, assuming we can load the entire dict of tbatches into memory and do random access on each dict (needed to account for user changes to timespan).

However, the current code isn't set up to incorporate these changes easily, because chunks of t-batches are computed on-the-fly, trading off with the corresponding chunk of the epoch. So one would have to compute the "start" and "end" points of each tbatch chunk so that the epoch chunk can access the right tbatches. 

The code in the 4th commit is not just unoptimized, but buggy. In the first epoch, the tbatch dicts keep growing, as args.cache_tbatches=True removes tbatch reinitialization. But the epoch still iterates over the full length of the tbatch dicts. There are a two competing ways one could fix this:

1) Revert to reinitializing the tbatch chunk every time, but save the tbatch chunks to disk.

2) Tell the epoch where to access the tbatch dict, instead of starting from the beginning.

2 seems easier, but I will leave that to the code maintainers' judgement :)